### PR TITLE
添加对外部AudioClip的加载接口

### DIFF
--- a/Source/Scripts/UI/Transition.cs
+++ b/Source/Scripts/UI/Transition.cs
@@ -941,7 +941,7 @@ namespace FairyGUI
 					break;
 
 				case TransitionActionType.Sound:
-					AudioClip sound = UIPackage.GetItemAssetByURL(value.s) as AudioClip;
+					AudioClip sound = UIConfig.LoadSound(value.s);
 					if (sound != null)
 						Stage.inst.PlayOneShotSound(sound, value.f1);
 					break;

--- a/Source/Scripts/UI/UIConfig.cs
+++ b/Source/Scripts/UI/UIConfig.cs
@@ -354,5 +354,21 @@ namespace FairyGUI
 		{ 
 			//nothing yet
 		}
+
+		public delegate AudioClip SoundLoader(string url);
+		static readonly SoundLoader defaultSoundLoader = url => null;
+		static SoundLoader soundLoader = defaultSoundLoader;
+
+		public static void SetSoundLoader(SoundLoader loader)
+		{
+			soundLoader = loader ?? defaultSoundLoader;
+		}
+
+		internal static AudioClip LoadSound(string url)
+		{
+			if (url.StartsWith(UIPackage.URL_PREFIX))
+				return UIPackage.GetItemAssetByURL(url) as AudioClip;
+			return soundLoader(url);
+		}
 	}
 }

--- a/Source/Scripts/UI/UIObjectFactory.cs
+++ b/Source/Scripts/UI/UIObjectFactory.cs
@@ -29,7 +29,7 @@ namespace FairyGUI
 		/// 
 		/// </summary>
 		/// <param name="url"></param>
-		/// <param name="method"></param>
+		/// <param name="creator"></param>
 		public static void SetPackageItemExtension(string url, GComponentCreator creator)
 		{
 			if (url == null)
@@ -62,8 +62,8 @@ namespace FairyGUI
 
 		internal static void ResolvePackageItemExtension(PackageItem pi)
 		{
-			if (!packageItemExtensions.TryGetValue("ui://" + pi.owner.id + pi.id, out pi.extensionCreator)
-				&& !packageItemExtensions.TryGetValue("ui://" + pi.owner.name + "/" + pi.name, out pi.extensionCreator))
+			if (!packageItemExtensions.TryGetValue(UIPackage.URL_PREFIX + pi.owner.id + pi.id, out pi.extensionCreator)
+				&& !packageItemExtensions.TryGetValue(UIPackage.URL_PREFIX + pi.owner.name + "/" + pi.name, out pi.extensionCreator))
 				pi.extensionCreator = null;
 		}
 


### PR DESCRIPTION
动效支持播放没有导入fairygui编辑器中的声音(需自己设置加载函数)。同时可以利用这个接口做其他支持(如event://用于事件通知)