### PR TITLE
add shader keyword PREMULAPLHA, when BlendMode is Multiply or Screen

### DIFF
--- a/Source/Resources/Shaders/FairyGUI-Image.shader
+++ b/Source/Resources/Shaders/FairyGUI-Image.shader
@@ -49,6 +49,7 @@ Shader "FairyGUI/Image"
 				#pragma multi_compile NOT_COMBINED COMBINED
 				#pragma multi_compile NOT_GRAYED GRAYED COLOR_FILTER
 				#pragma multi_compile NOT_CLIPPED CLIPPED SOFT_CLIPPED ALPHA_MASK
+				#pragma multi_compile NOT_PREMULALPHA PREMULALPHA
 				#pragma vertex vert
 				#pragma fragment frag
 				
@@ -152,6 +153,10 @@ Shader "FairyGUI/Image"
 					col2.b = dot(col, _ColorMatrix[2])+_ColorOffset.z;
 					col2.a = dot(col, _ColorMatrix[3])+_ColorOffset.w;
 					col = col2;
+					#endif
+
+					#ifdef PREMULALPHA
+					col.rgb *= col.a;
 					#endif
 
 					#ifdef ALPHA_MASK

--- a/Source/Scripts/Core/MaterialManager.cs
+++ b/Source/Scripts/Core/MaterialManager.cs
@@ -162,6 +162,16 @@ namespace FairyGUI
 			}
 			nm.material.hideFlags = DisplayOptions.hideFlags;
 
+			switch (blendMode)
+			{
+				case BlendMode.Multiply:
+				case BlendMode.Screen:
+					nm.material.EnableKeyword("PREMULALPHA");
+					break;
+				default:
+					break;
+			}
+
 			return nm;
 		}
 


### PR DESCRIPTION
The correct display with BlendMode.Multiply and Screen require pre-multiply alpha value with output color.
Adding a simple keyword PREMULALPHA only in these BlendModes, cost a very very little performance.
