### PR TITLE
add image render color correct in linear color space

### DIFF
--- a/Examples.Unity5/Assets/FairyGUI/Resources/Shaders/FairyGUI-Image.shader
+++ b/Examples.Unity5/Assets/FairyGUI/Resources/Shaders/FairyGUI-Image.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Upgrade NOTE: replaced '_Object2World' with 'unity_ObjectToWorld'
 
 Shader "FairyGUI/Image"
@@ -48,7 +50,7 @@ Shader "FairyGUI/Image"
 		Pass
 		{
 			CGPROGRAM
-				#pragma multi_compile NOT_COMBINED COMBINED
+				#pragma multi_compile NOT_COMBINED COMBINED GAMMA_SPACE_CORRECT
 				#pragma multi_compile NOT_GRAYED GRAYED COLOR_FILTER
 				#pragma multi_compile NOT_CLIPPED CLIPPED SOFT_CLIPPED ALPHA_MASK
 				#pragma vertex vert
@@ -101,9 +103,13 @@ Shader "FairyGUI/Image"
 				v2f vert (appdata_t v)
 				{
 					v2f o;
-					o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+					o.vertex = UnityObjectToClipPos(v.vertex);
 					o.texcoord = v.texcoord;
+					#ifdef GAMMA_SPACE_CORRECT
+					o.color = pow( v.color, 2.2 );
+					#else
 					o.color = v.color;
+					#endif
 
 					#ifdef CLIPPED
 					o.clipPos = mul(unity_ObjectToWorld, v.vertex).xy * _ClipBox.zw + _ClipBox.xy;


### PR DESCRIPTION
1》设置fairygui导入的贴图的设置，在sRGB(color Texture) 选项去掉勾，表示使用linear color space色彩
2》在程序里面添加shader define。Shader.EnableKeyword("GAMMA_SPACE_CORRECT");

问题重新，使用fairygui工具做的ui导入到unity里面，只要使用了一个Image组件，并且手动给它上色，意思就是透明贴图上色，那么在linear color space里面，unity渲染的效果和fairygui editor看到的就是两个效果，这个修正保证一致性