### PR TITLE
[*]在继承了FreeExternal接口以后,如果整个Loader依托于AssetBundle的情况下,会出现资源释放问题.

### DIFF
--- a/Assets/Scripts/UI/GLoader.cs
+++ b/Assets/Scripts/UI/GLoader.cs
@@ -74,6 +74,7 @@ namespace FairyGUI
 				if (_url == value)
 					return;
 
+				ClearContent();
 				_url = value;
 				LoadContent();
 				UpdateGear(7);
@@ -653,7 +654,10 @@ namespace FairyGUI
 			}
 
 			if (!string.IsNullOrEmpty(_url))
-				LoadContent();
+		    {
+                ClearContent();
+		        LoadContent();
+            }
 		}
 	}
 }


### PR DESCRIPTION
谷主您好
在使用fgui的过程中发现了一个小问题.
对于装载器来说我们在使用中一般是配合AssetBundleManager来使用
那么在默认的接口中FreeExternal回传的参数是NTexture,回传的不是之前的url这样其实对于不改动fgui源码的基础上来结合AssetBundleManager使用就会出现卸载这里会比较麻烦的情况.
因为AssetBundleManager无法明确我需要卸载的文件具体是什么.如果改动原有FreeExternal回传一个url这样虽然可以解决这个问题,但是整体改动可能会略大,因为还需要添加一个记录之前url的值
所以目前进行了这样的修改.
我在FreeExternal中直接进行Mgr.Release(url)操作.
你看下是否可以pr合并.