### PR TITLE
允许触摸空白图形

### DIFF
--- a/Assets/Scripts/Core/Shape.cs
+++ b/Assets/Scripts/Core/Shape.cs
@@ -211,8 +211,8 @@ namespace FairyGUI
 
         protected override DisplayObject HitTest()
         {
-            if (graphics.meshFactory == null)
-                return null;
+            //if (graphics.meshFactory == null)
+            //    return null;
 
             Vector2 localPoint = WorldToLocal(HitTestContext.worldPoint, HitTestContext.direction);
 


### PR DESCRIPTION
由于图片不可被触摸，有时会需要一个可触摸的区域，但是不想被渲染，所以图形就很合适。
但是目前空白图形不能接受触摸，需要让空白图形接受触摸。
如果该空白图形本身是为了装载粒子效果，而不想被触摸，那么只需要勾选 `不可触摸` 就可以了。