### PR TITLE
Enable GComponent.GetChildByPath to go inside GLoader

### DIFF
--- a/Assets/Scripts/UI/GComponent.cs
+++ b/Assets/Scripts/UI/GComponent.cs
@@ -392,13 +392,15 @@ namespace FairyGUI
 
                 if (i != cnt - 1)
                 {
-                    if (!(gcom is GComponent))
+                    if (obj is GComponent)
+                        gcom = obj.asCom;
+                    else if (obj is GLoader)
+                        gcom = obj.asLoader.component;
+                    else
                     {
                         obj = null;
                         break;
                     }
-                    else
-                        gcom = (GComponent)obj;
                 }
             }
 


### PR DESCRIPTION
It seems nice to be able to traverse inside GLoader component hierarchy. But not 100% sure if this is valid approach.