### PR TITLE
增加挂载package时异步加载资源

### DIFF
--- a/Assets/Scripts/Core/NAudioClip.cs
+++ b/Assets/Scripts/Core/NAudioClip.cs
@@ -38,6 +38,10 @@ namespace FairyGUI
                 Resources.UnloadAsset(nativeClip);
             else if (destroyMethod == DestroyMethod.Destroy)
                 Object.DestroyImmediate(nativeClip, true);
+            else if (destroyMethod == DestroyMethod.AsyncResource)
+            {
+                UIPackage.AsyncLoadResource?.ReleaseResource(nativeClip);
+            }
 
             nativeClip = null;
         }

--- a/Assets/Scripts/Core/NTexture.cs
+++ b/Assets/Scripts/Core/NTexture.cs
@@ -13,7 +13,8 @@ namespace FairyGUI
         Destroy,
         Unload,
         None,
-        ReleaseTemp
+        ReleaseTemp,
+		AsyncResource,
     }
 
     /// <summary>
@@ -423,6 +424,13 @@ namespace FairyGUI
                 RenderTexture.ReleaseTemporary((RenderTexture)_nativeTexture);
                 if (_alphaTexture is RenderTexture)
                     RenderTexture.ReleaseTemporary((RenderTexture)_alphaTexture);
+            }else if (destroyMethod == DestroyMethod.AsyncResource)
+            {
+                UIPackage.AsyncLoadResource?.ReleaseResource(_nativeTexture);
+                if (_alphaTexture != null)
+                {
+                    UIPackage.AsyncLoadResource?.ReleaseResource(_alphaTexture);
+                }
             }
 
             _nativeTexture = null;

--- a/Assets/Scripts/UI/UIPackage.cs
+++ b/Assets/Scripts/UI/UIPackage.cs
@@ -369,7 +369,7 @@ namespace FairyGUI
                     
                     ByteBuffer buffer = new ByteBuffer(textAsset.bytes);
                     UIPackage pkg = new UIPackage {_assetPath = assetPath};
-                    pkg.LoadPackageAsync(buffer, assetPath, assetPath, package =>
+                    pkg.LoadPackageAsync(buffer, assetPath, package =>
                     {
                         if (package != null)
                         {
@@ -688,9 +688,9 @@ namespace FairyGUI
             return o;
         }
 
-        void LoadPackageAsync(ByteBuffer buffer, string packageSource, string assetNamePrefix, Action<UIPackage> callback)
+        void LoadPackageAsync(ByteBuffer buffer, string assetNamePrefix, Action<UIPackage> callback)
         {
-            if (!LoadPackage(buffer, packageSource, assetNamePrefix))
+            if (!LoadPackage(buffer, assetNamePrefix))
             {
                 callback?.Invoke(null);
                 return;


### PR DESCRIPTION
目前unity Addressables 资源加载都在模糊ab的概念 不少unity框架ab对上层来说也是黑盒 包装成需要什么资源异步加载什么资源的模型 而目前fgui挂载package虽然有自定义加载接口但是是同步的方式这就导致类似addressables的加载模型无法正常加载资源 因此增加异步挂载package的方法 望采纳