### PR TITLE
calculate Spine localScale to fix SkeletonDataAsset.scale * "fixed scale" = 1

### DIFF
--- a/Assets/Extensions/Spine/SpineLoader.cs
+++ b/Assets/Extensions/Spine/SpineLoader.cs
@@ -21,6 +21,29 @@ namespace FairyGUI
             get { return _spineAnimation; }
         }
 
+        public Color color
+        {
+            get => this._color;
+            set
+            {
+                this._color = value;
+                if (this._spineAnimation == null || this._spineAnimation.skeleton == null)
+                    return;
+                this._spineAnimation.skeleton.R = this.color.r;
+                this._spineAnimation.skeleton.G = this.color.g;
+                this._spineAnimation.skeleton.B = this.color.b;
+            }
+        }
+        
+        protected override void HandleAlphaChanged()
+        {
+            base.HandleAlphaChanged();
+            if (this._spineAnimation != null && this._spineAnimation.skeleton != null)
+            {
+                this._spineAnimation.skeleton.A = this.alpha;
+            }
+        }
+
         /// <summary>
         /// 
         /// </summary>
@@ -87,6 +110,10 @@ namespace FairyGUI
                 _spineAnimation.skeleton.SetSkin(skin);
                 _spineAnimation.skeleton.SetSlotsToSetupPose();
             }
+            
+            // change color and alpha
+            color = _color;
+            HandleAlphaChanged();
         }
 
         protected void FreeSpine()

--- a/Assets/Extensions/Spine/SpineLoader.cs
+++ b/Assets/Extensions/Spine/SpineLoader.cs
@@ -35,7 +35,7 @@ namespace FairyGUI
             _spineAnimation = SkeletonRenderer.NewSpineGameObject<SkeletonAnimation>(asset);
             _spineAnimation.gameObject.name = asset.name;
             Spine.SkeletonData dat = asset.GetSkeletonData(false);
-            _spineAnimation.gameObject.transform.localScale = new Vector3(100, 100, 1);
+            _spineAnimation.gameObject.transform.localScale = new Vector3(1 / asset.scale, 1 / asset.scale, 1);
             _spineAnimation.gameObject.transform.localPosition = new Vector3(anchor.x, -anchor.y, 0);
             SetWrapTarget(_spineAnimation.gameObject, true, width, height);
 

--- a/Assets/Scripts/UI/GLoader3D.cs
+++ b/Assets/Scripts/UI/GLoader3D.cs
@@ -269,6 +269,8 @@ namespace FairyGUI
             set { _content.shader = value; }
         }
 
+        private Color _color = Color.white;
+#if !FAIRYGUI_SPINE
         /// <summary>
         /// Not implemented.
         /// </summary>
@@ -277,6 +279,7 @@ namespace FairyGUI
             get;
             set;
         }
+#endif // FAIRYGUI_SPINE
 
         /// <summary>
         /// 
@@ -519,7 +522,7 @@ namespace FairyGUI
             _loop = buffer.ReadBool();
 
             if (buffer.ReadBool())
-                buffer.ReadColor(); //color
+                _color = buffer.ReadColor(); //color
 
             if (!string.IsNullOrEmpty(_url))
                 LoadContent();


### PR DESCRIPTION
Considering that the default SpineSettings Settings are different for each project, writing in this way can have better compatibility