### PR TITLE
FIX Spine & DragoneBones memory leak when UIPackage Dispose

### DIFF
--- a/Assets/Scripts/UI/UIPackage.cs
+++ b/Assets/Scripts/UI/UIPackage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
 using FairyGUI.Utils;
+using Object = UnityEngine.Object;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -1012,6 +1013,14 @@ namespace FairyGUI
                     {
                         pi.audioClip.Unload();
                         pi.audioClip = null;
+                    }
+                }
+                else if (pi.type == PackageItemType.DragoneBones || pi.type == PackageItemType.Spine)
+                {
+                    if (pi.skeletonAsset != null)
+                    {
+                        Object.DestroyImmediate((Object)pi.skeletonAsset, true);
+                        pi.skeletonAsset = null;
                     }
                 }
             }


### PR DESCRIPTION
现销毁的时候没有释放骨骼动画的资源，在Dispose的时候添加了销毁接口

FIXME: 考虑到UnloadAssets和ReloadAssets接口都是Editor用到的接口，所以不好刻意修改了。不过建议在代码中添加宏或提醒其他玩家不要使用这两个接口，因为在项目中这个代码是无法正确被执行的

目前Editor下报告一个问题：
Spine动画首次导入后会记录下动画的大小，但是更新动画文件的时候动画的大小并没有更新，需要先删除再添加刷新才生效，不知道是不是也和ReloadAssets没有处理有关系，所以在此处提上一嘴