### PR TITLE
增加代码健壮性，避免重复执行销毁流程（导致引用计数不准确）

### DIFF
--- a/Assets/Scripts/UI/GLoader.cs
+++ b/Assets/Scripts/UI/GLoader.cs
@@ -49,6 +49,9 @@ namespace FairyGUI
 
         override public void Dispose()
         {
+            if (_disposed) return;
+            _disposed = true;
+
             if (_content.texture != null)
             {
                 if (_contentItem == null)


### PR DESCRIPTION
GLoader重载Dispose的时候没有判定是否已销毁，增加判定