### PR TITLE
window 在异步加载资源的时候 发生意外关闭  通知接口取消加载以及善后 避免window被销毁后产生回调抛异常

### DIFF
--- a/Assets/Scripts/UI/IUISource.cs
+++ b/Assets/Scripts/UI/IUISource.cs
@@ -26,5 +26,11 @@ namespace FairyGUI
         /// </summary>
         /// <param name="callback"></param>
         void Load(UILoadCallback callback);
+
+        /// <summary>
+        /// 取消加载
+        /// </summary>
+        void Cancel();
+        
     }
 }

--- a/Assets/Scripts/UI/Window.cs
+++ b/Assets/Scripts/UI/Window.cs
@@ -496,6 +496,17 @@ namespace FairyGUI
             if (_modalWaitPane != null && _modalWaitPane.parent == null)
                 _modalWaitPane.Dispose();
 
+
+            //正在加载资源的异步过程中发生意外关闭 应该取消正在加载的load
+            if (!_inited)
+            {
+                for (int i = 0; i < _uiSources.Count; ++i)
+                {
+                    _uiSources[i].Cancel();
+                }
+            }
+            
+
 #if FAIRYGUI_PUERTS
             __onInit = null;
             __onShown = null;

--- a/Assets/Scripts/UI/Window.cs
+++ b/Assets/Scripts/UI/Window.cs
@@ -498,7 +498,7 @@ namespace FairyGUI
 
 
             //正在加载资源的异步过程中发生意外关闭 应该取消正在加载的load
-            if (!_inited)
+            if (_loading)
             {
                 for (int i = 0; i < _uiSources.Count; ++i)
                 {


### PR DESCRIPTION
window 在异步加载资源的时候 发生意外关闭  通知接口取消加载以及善后 避免window被销毁后产生回调抛异常