### PR TITLE
feat: UIConfig增加 disableDisplayObjectInfo 可禁用DisplayObjectInfo的构造（Dis…

### DIFF
--- a/Assets/Scripts/Core/DisplayObject.cs
+++ b/Assets/Scripts/Core/DisplayObject.cs
@@ -234,8 +234,11 @@ namespace FairyGUI
             {
                 UnityEngine.Object.DontDestroyOnLoad(gameObject);
 
-                DisplayObjectInfo info = gameObject.AddComponent<DisplayObjectInfo>();
-                info.displayObject = this;
+                if (!UIConfig.disableDisplayObjectInfo)
+                {
+                    DisplayObjectInfo info = gameObject.AddComponent<DisplayObjectInfo>();
+                    info.displayObject = this;
+                }
             }
             gameObject.hideFlags = DisplayObject.hideFlags;
             gameObject.SetActive(false);

--- a/Assets/Scripts/UI/UIConfig.cs
+++ b/Assets/Scripts/UI/UIConfig.cs
@@ -179,6 +179,14 @@ namespace FairyGUI
         /// </summary>
         public static bool makePixelPerfect = false;
 
+
+        /// <summary>
+        /// If disable DisplayObjectInfo. Developers will not be able to visually edit
+        /// DisplayObject properties in Editor mode, nor will they be able to connect to
+        /// the Poco SDK to get or set object properties
+        /// </summary>
+        public static bool disableDisplayObjectInfo = false;
+
         public enum ConfigKey
         {
             DefaultFont,


### PR DESCRIPTION
目前DisplayObjectInfo是一定会创建的，但是考虑到Distribute模式下的性能优化，希望不要构造该对象，增加了一个开关用于关闭DisplayObjectInfo的构造