### PR TITLE
feat: DisplayObjectInfo显示Render Order

### DIFF
--- a/Assets/Scripts/Editor/DisplayObjectEditor.cs
+++ b/Assets/Scripts/Editor/DisplayObjectEditor.cs
@@ -120,6 +120,17 @@ namespace FairyGUIEditor
                 string icon = EditorGUILayout.TextField("Icon", gObj.icon);
                 if (EditorGUI.EndChangeCheck())
                     gObj.icon = icon;
+
+                if (gObj.displayObject != null)
+                {
+                    EditorGUI.BeginDisabledGroup(true);
+                    EditorGUI.BeginChangeCheck();
+                    EditorGUILayout.BeginHorizontal();
+                    EditorGUILayout.PrefixLabel("Rendering Order");
+                    EditorGUILayout.IntField(gObj.displayObject.renderingOrder);
+                    EditorGUILayout.EndHorizontal();
+                    EditorGUI.EndDisabledGroup();
+                }
             }
         }
     }


### PR DESCRIPTION
有的时候在做动画的时候，由于开启了invalidateBatchingEveryFrame可能会导致遮挡问题，为更快速的定位问题，希望能将Render Order在编辑器下显示出来