### PR TITLE
Glist 自定义数据绑定

### DIFF
--- a/Assets/Scripts/UI/GList.cs
+++ b/Assets/Scripts/UI/GList.cs
@@ -71,6 +71,7 @@ namespace FairyGUI
         bool _virtual;
         bool _loop;
         int _numItems;
+        List<object> _dataList; // list自身绑定的数据
         int _realNumItems;
         int _firstIndex; //the top left index
         int _curLineItemCount; //item count in one line
@@ -104,7 +105,8 @@ namespace FairyGUI
             rootContainer.gameObject.name = "GList";
 
             _pool = new GObjectPool(container.cachedTransform);
-
+            _dataList = new List<object>();
+            
             _itemClickDelegate = __clickItem;
         }
 
@@ -118,7 +120,8 @@ namespace FairyGUI
             scrollItemToViewOnClick = false;
             itemRenderer = null;
             itemProvider = null;
-
+            _dataList.Clear();
+            _dataList = null;
             base.Dispose();
         }
 
@@ -1501,6 +1504,22 @@ namespace FairyGUI
         }
 
         /// <summary>
+        /// 设置list数据源
+        /// 设置后会绑定数据在每个子对象，可以根据 dataSource 来直接获取数据
+        /// </summary>
+        public List<object> dataList
+        {
+            get{
+                return _dataList;
+            }
+            set
+            {
+                _dataList = value;
+                numItems = value.Count;
+            }
+        }
+
+        /// <summary>
         /// Set the list item count. 
         /// If the list is not virtual, specified number of items will be created. 
         /// If the list is virtual, only items in view will be created.
@@ -1571,7 +1590,14 @@ namespace FairyGUI
                     if (itemRenderer != null)
                     {
                         for (int i = 0; i < value; i++)
-                            itemRenderer(i, GetChildAt(i));
+                        {
+                            var child = GetChildAt(i);
+                            if (i < _dataList.Count)
+                            {// 赋值
+                                child.dataSource = _dataList[i];
+                            }
+                            itemRenderer(i, child);
+                        }
                     }
                 }
             }
@@ -2032,6 +2058,11 @@ namespace FairyGUI
                     if (_autoResizeItem && (_layout == ListLayoutType.SingleColumn || _columnCount > 0))
                         ii.obj.SetSize(partSize, ii.obj.height, true);
 
+                    if (curIndex % _numItems < _dataList.Count)
+                    {// 赋值
+                        ii.obj.dataSource = _dataList[curIndex % _numItems];
+                    }
+                    
                     itemRenderer(curIndex % _numItems, ii.obj);
                     if (curIndex % _curLineItemCount == 0)
                     {
@@ -2201,6 +2232,11 @@ namespace FairyGUI
                     if (_autoResizeItem && (_layout == ListLayoutType.SingleRow || _lineCount > 0))
                         ii.obj.SetSize(ii.obj.width, partSize, true);
 
+                    if (curIndex % _numItems < _dataList.Count)
+                    {// 赋值
+                        ii.obj.dataSource = _dataList[curIndex % _numItems];
+                    }
+                    
                     itemRenderer(curIndex % _numItems, ii.obj);
                     if (curIndex % _curLineItemCount == 0)
                     {
@@ -2381,6 +2417,11 @@ namespace FairyGUI
                             ii.obj.SetSize(partWidth, ii.obj.height, true);
                         else if (_curLineItemCount2 == _lineCount)
                             ii.obj.SetSize(ii.obj.width, partHeight, true);
+                    }
+                    
+                    if (i % _numItems < _dataList.Count)
+                    {// 赋值
+                        ii.obj.dataSource = _dataList[i % _numItems];
                     }
 
                     itemRenderer(i % _numItems, ii.obj);

--- a/Assets/Scripts/UI/GObject.cs
+++ b/Assets/Scripts/UI/GObject.cs
@@ -23,6 +23,12 @@ namespace FairyGUI
         public object data;
 
         /// <summary>
+        /// User defined data.
+        /// GList 内部会赋值
+        /// </summary>
+        public object dataSource;
+
+        /// <summary>
         /// The source width of the object.
         /// </summary>
         public int sourceWidth;


### PR DESCRIPTION
遇到问题：项目上遇到GList嵌套GList的时候，嵌套的GList数据源不怎么好获取，

解决办法：直接调用 Glist dataList方法可以直接把数据直接绑定至每个对象上，这样在 itemRenderer 调用的时候可以直接获取每个对象绑定的数据，感觉这样方便获取。 注：为了不和原来的版本冲突，所以定义了一个新的变量 dataSource，这样也可以兼容以前的版本