### PR TITLE
Support TextMeshPro font fallback feature.

### DIFF
--- a/Assets/Extensions/TextMeshPro/TMPFont.cs
+++ b/Assets/Extensions/TextMeshPro/TMPFont.cs
@@ -242,16 +242,26 @@ namespace FairyGUI
         {
             isFallback = false;
             _char = GetCharacterFromFontAsset(ch, _style, false);
-            if (_char == null)
+            float charWidth = 0;            
+            if (_char != null)
+            {
+                charWidth = _char.glyph.metrics.horizontalAdvance;
+            }
+            else
             {
                 _char = GetCharacterFromFontAsset(ch, _style, true);
-                if (_char != null)
+                if (_char != null && _char.textAsset is TMP_FontAsset fallbackAsset)
+                {
                     isFallback = true;
+                    float ratio = fallbackAsset.faceInfo.scale / fallbackAsset.faceInfo.pointSize
+                        / _fontAsset.faceInfo.scale * _fontAsset.faceInfo.pointSize;
+                    charWidth = _char.glyph.metrics.horizontalAdvance * ratio;
+                }
             }
 
             if (_char != null)
             {
-                width = _char.glyph.metrics.horizontalAdvance * _boldMultiplier * _scale;
+                width = charWidth * _boldMultiplier * _scale;
                 height = _lineHeight * _scale;
                 baseline = _ascent * _scale;
 

--- a/Assets/Extensions/TextMeshPro/TMPFont.cs
+++ b/Assets/Extensions/TextMeshPro/TMPFont.cs
@@ -232,6 +232,11 @@ namespace FairyGUI
 
             format.FillVertexColors(vertexColors);
         }
+        
+        public TextFormat GetTextFormat()
+        {
+            return _format;
+        }
 
         override public bool GetGlyph(char ch, out float width, out float height, out float baseline, out bool isFallback)
         {

--- a/Assets/Extensions/TextMeshPro/TMPSubTextField.cs
+++ b/Assets/Extensions/TextMeshPro/TMPSubTextField.cs
@@ -1,0 +1,185 @@
+#if FAIRYGUI_TMPRO
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+
+namespace FairyGUI
+{
+    public class TMPSubTextField : DisplayObject, IMeshFactory
+    {
+        public struct CharInfo
+        {
+            public TMP_Character character;
+            public short lineIndex;
+            public float px;
+            public float py;
+            /// <summary>
+            /// 字符占用的顶点数量。
+            /// </summary>
+            public short vertCount;
+
+            public CharInfo(TMP_Character character, short lineIndex, float px, float py)
+            {
+                this.character = character;
+                this.lineIndex = lineIndex;
+                this.px = px;
+                this.py = py;
+                vertCount = 0;
+            }
+        }
+        
+        public struct LineInfo
+        {
+            public short lineIndex;
+            public float px;
+            public float py;
+            public float width;
+            public int fontSize;
+
+            public LineInfo(short lineIndex, float px, float py, float width, int fontSize)
+            {
+                this.lineIndex = lineIndex;
+                this.px = px;
+                this.py = py;
+                this.width = width;
+                this.fontSize = fontSize;
+            }
+            
+            public void Set(short lineIndex, float px, float py, float width, int fontSize)
+            {
+                this.lineIndex = lineIndex;
+                this.px = px;
+                this.py = py;
+                this.width = width;
+                this.fontSize = fontSize;
+            }
+        }
+
+        private TextField _textField;
+        private TMPFont _font { set; get; }
+        public TMPFont font
+        {
+            get => _font;
+            set
+            {
+                if (_font == value) return;
+                _font = value;
+                graphics.SetShaderAndTexture(_font.shader, _font.mainTexture);
+            }
+        }
+
+        private List<CharInfo> _toRendererChars = new List<CharInfo>();
+        public List<CharInfo> toRendererChars => _toRendererChars;
+        private List<LineInfo> _underlineInfos = new List<LineInfo>();
+        private List<LineInfo> _strikethroughInfos = new List<LineInfo>();
+
+        public TMPSubTextField(TextField textField)
+        {
+            _textField = textField;
+            _flags |= Flags.TouchDisabled;
+
+            CreateGameObject("SubTextField");
+            graphics = new NGraphics(gameObject);
+            graphics.meshFactory = this;
+
+            gOwner = textField.gOwner;
+        }
+        
+        public void OnPopulateMesh(VertexBuffer vb)
+        {
+            List<Vector3> vertList = vb.vertices;
+            List<Vector2> uvList = vb.uvs;
+            List<Vector2> uv2List = vb.uvs2;
+            List<Color32> colList = vb.colors;
+
+            int underlineIndex = 0;
+            int strikethroughIndex = 0;
+            for (int i = 0, charCount = _toRendererChars.Count; i < charCount; i++)
+            {
+                var charInfo = _toRendererChars[i];
+                charInfo.vertCount = (short)_font.DrawGlyph(charInfo.character, charInfo.px, charInfo.py, vertList, uvList, uv2List, colList);
+
+                // end of line
+                if (i == charCount - 1 || charInfo.lineIndex != _toRendererChars[i + 1].lineIndex)
+                {
+                    int lineVertCount = 0;
+                    for (int infoCount = _underlineInfos.Count; underlineIndex < infoCount; underlineIndex++)
+                    {
+                        var lineInfo = _underlineInfos[underlineIndex];
+                        if (lineInfo.lineIndex == charInfo.lineIndex)
+                        {
+                            lineVertCount += _font.DrawLine(lineInfo.px, lineInfo.py, lineInfo.width, lineInfo.fontSize, 0, vertList, uvList, uv2List, colList);
+                            break;
+                        }
+                    }
+                    for (int infoCount = _strikethroughInfos.Count; strikethroughIndex < infoCount; strikethroughIndex++)
+                    {
+                        var lineInfo = _strikethroughInfos[strikethroughIndex];
+                        if (lineInfo.lineIndex == charInfo.lineIndex)
+                        {
+                            lineVertCount += _font.DrawLine(lineInfo.px, lineInfo.py, lineInfo.width, lineInfo.fontSize, 1, vertList, uvList, uv2List, colList);
+                            break;
+                        }
+                    }
+                    if (lineVertCount > 0)
+                        charInfo.vertCount += (short) lineVertCount;
+                }
+                
+                _toRendererChars[i] = charInfo;
+            }
+
+            int count = vertList.Count;
+            if (count > 65000)
+            {
+                Debug.LogWarning("Text is too large. A mesh may not have more than 65000 vertices.");
+                vertList.RemoveRange(65000, count - 65000);
+                colList.RemoveRange(65000, count - 65000);
+                uvList.RemoveRange(65000, count - 65000);
+                if (uv2List.Count > 0)
+                    uv2List.RemoveRange(65000, count - 65000);
+                count = 65000;
+            }
+            
+            vb.AddTriangles();
+        }
+
+        public int AddToRendererChar(TMP_Character ch, short lineIndex, float px, float py)
+        {
+            int index = _toRendererChars.Count;
+            _toRendererChars.Add(new CharInfo(ch, lineIndex, px, py));
+            return index;
+        }
+
+        public void AddUnderline(short lineIndex, float px, float py, float width, int fontSize)
+        {
+            _underlineInfos.Add(new LineInfo(lineIndex, px, py, width, fontSize));
+        }
+        
+        public void AddStrikethrough(short lineIndex, float px, float py, float width, int fontSize)
+        {
+            _strikethroughInfos.Add(new LineInfo(lineIndex, px, py, width, fontSize));
+        }
+
+        public bool ForceUpdateMesh()
+        {
+            graphics.SetMeshDirty();
+            return graphics.UpdateMesh();
+        }
+        
+        public void CleanUp()
+        {
+            _toRendererChars.Clear();
+            _underlineInfos.Clear();
+            _strikethroughInfos.Clear();
+        }
+        
+        public void Clear()
+        {
+            CleanUp();
+            graphics.mesh.Clear();
+            graphics.SetMeshDirty();
+        }
+    }
+}
+
+#endif

--- a/Assets/Extensions/TextMeshPro/TMPSubTextField.cs
+++ b/Assets/Extensions/TextMeshPro/TMPSubTextField.cs
@@ -99,7 +99,7 @@ namespace FairyGUI
                 var charInfo = _toRendererChars[i];
                 charInfo.vertCount = (short)_font.DrawGlyph(charInfo.character, charInfo.px, charInfo.py, vertList, uvList, uv2List, colList);
 
-                // end of line
+                // End of line
                 if (i == charCount - 1 || charInfo.lineIndex != _toRendererChars[i + 1].lineIndex)
                 {
                     int lineVertCount = 0;
@@ -109,6 +109,7 @@ namespace FairyGUI
                         if (lineInfo.lineIndex == charInfo.lineIndex)
                         {
                             lineVertCount += _font.DrawLine(lineInfo.px, lineInfo.py, lineInfo.width, lineInfo.fontSize, 0, vertList, uvList, uv2List, colList);
+                            underlineIndex++; // Move next
                             break;
                         }
                     }
@@ -118,6 +119,7 @@ namespace FairyGUI
                         if (lineInfo.lineIndex == charInfo.lineIndex)
                         {
                             lineVertCount += _font.DrawLine(lineInfo.px, lineInfo.py, lineInfo.width, lineInfo.fontSize, 1, vertList, uvList, uv2List, colList);
+                            strikethroughIndex++; // Move next
                             break;
                         }
                     }

--- a/Assets/Extensions/TextMeshPro/TMPSubTextField.cs
+++ b/Assets/Extensions/TextMeshPro/TMPSubTextField.cs
@@ -70,7 +70,6 @@ namespace FairyGUI
             uvList.AddRange(_preparedVertexBuffer.uvs);
             uv2List.AddRange(_preparedVertexBuffer.uvs2);
             colList.AddRange(_preparedVertexBuffer.colors);
-            DisposeVertexBuffer();
 
             int count = vertList.Count;
             if (count > 65000)
@@ -114,7 +113,9 @@ namespace FairyGUI
         public bool ForceUpdateMesh()
         {
             graphics.SetMeshDirty();
-            return graphics.UpdateMesh();
+            bool update = graphics.UpdateMesh();
+            DisposeVertexBuffer();
+            return update;
         }
         
         public void CleanUp()

--- a/Assets/Extensions/TextMeshPro/TMPSubTextField.cs
+++ b/Assets/Extensions/TextMeshPro/TMPSubTextField.cs
@@ -27,7 +27,6 @@ namespace FairyGUI
             public float width;
             public int fontSize;
 
-            public short lineIndex;
             public float px;
             public float py;
             /// <summary>
@@ -35,25 +34,23 @@ namespace FairyGUI
             /// </summary>
             public short vertCount;
 
-            public CharInfo(TMP_Character character, short lineIndex, float px, float py)
+            public CharInfo(TMP_Character character, float px, float py)
             {
                 type = SubMeshDrawType.Char;
                 this.character = character;
                 width = 0;
                 fontSize = 0;
-                this.lineIndex = lineIndex;
                 this.px = px;
                 this.py = py;
                 vertCount = 0;
             }
             
-            public CharInfo(SubMeshDrawType type, short lineIndex, float px, float py, float width, int fontSize)
+            public CharInfo(SubMeshDrawType type, float px, float py, float width, int fontSize)
             {
                 this.type = type;
                 character = null;
                 this.width = width;
                 this.fontSize = fontSize;
-                this.lineIndex = lineIndex;
                 this.px = px;
                 this.py = py;
                 vertCount = 0;
@@ -95,8 +92,6 @@ namespace FairyGUI
             List<Vector2> uv2List = vb.uvs2;
             List<Color32> colList = vb.colors;
 
-            int underlineIndex = 0;
-            int strikethroughIndex = 0;
             for (int i = 0, charCount = _toRendererChars.Count; i < charCount; i++)
             {
                 var charInfo = _toRendererChars[i];
@@ -124,17 +119,17 @@ namespace FairyGUI
             vb.AddTriangles();
         }
 
-        public int AddToRendererChar(TMP_Character ch, short lineIndex, float px, float py)
+        public int AddToRendererChar(TMP_Character ch, float px, float py)
         {
             int index = _toRendererChars.Count;
-            _toRendererChars.Add(new CharInfo(ch, lineIndex, px, py));
+            _toRendererChars.Add(new CharInfo(ch, px, py));
             return index;
         }
 
-        public int AddToRendererLine(int lineType, short lineIndex, float px, float py, float width, int fontSize)
+        public int AddToRendererLine(int lineType, float px, float py, float width, int fontSize)
         {
             int index = _toRendererChars.Count;
-            _toRendererChars.Add(new CharInfo(lineType == 0 ? SubMeshDrawType.Underline : SubMeshDrawType.Strikethrough, lineIndex, px, py, width, fontSize));
+            _toRendererChars.Add(new CharInfo(lineType == 0 ? SubMeshDrawType.Underline : SubMeshDrawType.Strikethrough, px, py, width, fontSize));
             return index;
         }
 

--- a/Assets/Extensions/TextMeshPro/TMPSubTextField.cs.meta
+++ b/Assets/Extensions/TextMeshPro/TMPSubTextField.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c3a09150d1cb462c9f224d9a26a1cf0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Extensions/TextMeshPro/TextFieldDisplay.cs
+++ b/Assets/Extensions/TextMeshPro/TextFieldDisplay.cs
@@ -1,0 +1,18 @@
+#if FAIRYGUI_TMPRO
+namespace FairyGUI
+{
+    public class TextFieldDisplay : DisplayObject
+    {
+        public TextFieldDisplay(TextField textField)
+        {
+            _flags |= Flags.TouchDisabled;
+
+            CreateGameObject("TextFieldDisplay");
+            graphics = new NGraphics(gameObject);
+            graphics.meshFactory = textField;
+
+            gOwner = textField.gOwner;
+        }
+    }
+}
+#endif

--- a/Assets/Extensions/TextMeshPro/TextFieldDisplay.cs.meta
+++ b/Assets/Extensions/TextMeshPro/TextFieldDisplay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8967702311f264c50b49d981d927ba2d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Text/BaseFont.cs
+++ b/Assets/Scripts/Core/Text/BaseFont.cs
@@ -71,11 +71,12 @@ namespace FairyGUI
         {
         }
 
-        virtual public bool GetGlyph(char ch, out float width, out float height, out float baseline)
+        virtual public bool GetGlyph(char ch, out float width, out float height, out float baseline, out bool isFallback)
         {
             width = 0;
             height = 0;
             baseline = 0;
+            isFallback = false;
             return false;
         }
 

--- a/Assets/Scripts/Core/Text/BitmapFont.cs
+++ b/Assets/Scripts/Core/Text/BitmapFont.cs
@@ -69,8 +69,9 @@ namespace FairyGUI
                 format.FillVertexColors(vertexColors);
         }
 
-        override public bool GetGlyph(char ch, out float width, out float height, out float baseline)
+        override public bool GetGlyph(char ch, out float width, out float height, out float baseline, out bool isFallback)
         {
+            isFallback = false;
             if (ch == ' ')
             {
                 width = Mathf.RoundToInt(size * _scale / 2);

--- a/Assets/Scripts/Core/Text/DynamicFont.cs
+++ b/Assets/Scripts/Core/Text/DynamicFont.cs
@@ -114,8 +114,9 @@ namespace FairyGUI
             _font.RequestCharactersInTexture(text, _size, _style);
         }
 
-        override public bool GetGlyph(char ch, out float width, out float height, out float baseline)
+        override public bool GetGlyph(char ch, out float width, out float height, out float baseline, out bool isFallback)
         {
+            isFallback = false;
             if (!_font.GetCharacterInfo(ch, out _char, _size, _style))
             {
                 if (ch == ' ')

--- a/Assets/Scripts/Core/Text/TextField.cs
+++ b/Assets/Scripts/Core/Text/TextField.cs
@@ -1520,8 +1520,18 @@ namespace FairyGUI
                             }
                             else
                             {
-                                _subTextFields[maxSubTextIndexInLine].AddUnderline((short)i, underlineStart < posx ? underlineStart : posx, -(line.y + line.baseline), lineWidth,
+                                int charIndex = _subTextFields[maxSubTextIndexInLine].AddToRendererLine(0, (short)i, underlineStart < posx ? underlineStart : posx, -(line.y + line.baseline), lineWidth,
                                     maxFontSize);
+                                // Add line
+                                if (_charPositions != null)
+                                {
+                                    CharPosition cp = new CharPosition();
+                                    cp.drawLineBySub = true;
+                                    cp.lineIndex = (short)i;
+                                    cp.subIndex = (short)(maxSubTextIndexInLine + 1);
+                                    cp.subCharIndex = charIndex;
+                                    _charPositions.Add(cp);
+                                }
                             }
 #endif
                         }
@@ -1546,8 +1556,18 @@ namespace FairyGUI
                             }
                             else
                             {
-                                _subTextFields[maxSubTextIndexInLine].AddStrikethrough((short)i, strikethroughStart < posx ? strikethroughStart : posx, -(line.y + line.baseline), lineWidth,
+                                int charIndex = _subTextFields[maxSubTextIndexInLine].AddToRendererLine(1, (short)i, strikethroughStart < posx ? strikethroughStart : posx, -(line.y + line.baseline), lineWidth,
                                     minFontSize);
+                                // Add line
+                                if (_charPositions != null)
+                                {
+                                    CharPosition cp = new CharPosition();
+                                    cp.drawLineBySub = true;
+                                    cp.lineIndex = (short)i;
+                                    cp.subIndex = (short)(maxSubTextIndexInLine + 1);
+                                    cp.subCharIndex = charIndex;
+                                    _charPositions.Add(cp);
+                                }
                             }
 #endif
                         }
@@ -1882,6 +1902,11 @@ namespace FairyGUI
             public short imgIndex;
             
 #if FAIRYGUI_TMPRO
+            /// <summary>
+            /// 是否使用submesh绘制line
+            /// </summary>
+            public bool drawLineBySub;
+            
             /// <summary>
             /// 大于0表示使用submesh
             /// </summary>

--- a/Assets/Scripts/Core/Text/TextField.cs
+++ b/Assets/Scripts/Core/Text/TextField.cs
@@ -1181,6 +1181,7 @@ namespace FairyGUI
                 if (_richTextField != null)
                     _richTextField.RefreshObjects();
 
+#if FAIRYGUI_TMPRO
                 int tmpLastCount = activeSubMeshCount;
                 activeSubMeshCount = 0;
                 foreach (var tmpSubTextField in _subTextFields)
@@ -1191,6 +1192,7 @@ namespace FairyGUI
             
                 if (activeSubMeshCount != tmpLastCount)
                     onActiveSubMeshCountChanged?.Invoke(activeSubMeshCount, tmpLastCount);
+#endif
                 return;
             }
 

--- a/Assets/Scripts/Core/Text/TextField.cs
+++ b/Assets/Scripts/Core/Text/TextField.cs
@@ -1447,7 +1447,7 @@ namespace FairyGUI
                         {
                             vertCount = 0;
                             TMPSubTextField subTextField = _subTextFields[subTextIndex];
-                            subCharIndex = subTextField.AddToRendererChar(currentTmpFont.currentChar, (short)i, posx, -(line.y + line.baseline));
+                            subCharIndex = subTextField.AddToRendererChar(currentTmpFont.currentChar, posx, -(line.y + line.baseline));
                         }
                         else
                         {
@@ -1520,17 +1520,16 @@ namespace FairyGUI
                             }
                             else
                             {
-                                int charIndex = _subTextFields[maxSubTextIndexInLine].AddToRendererLine(0, (short)i, underlineStart < posx ? underlineStart : posx, -(line.y + line.baseline), lineWidth,
-                                    maxFontSize);
-                                // Add line
+                                int charIndex = _subTextFields[maxSubTextIndexInLine].AddToRendererLine(0,
+                                    underlineStart < posx ? underlineStart : posx, -(line.y + line.baseline), lineWidth, maxFontSize);
+                                // line
                                 if (_charPositions != null)
                                 {
-                                    CharPosition cp = new CharPosition();
-                                    cp.drawLineBySub = true;
-                                    cp.lineIndex = (short)i;
-                                    cp.subIndex = (short)(maxSubTextIndexInLine + 1);
-                                    cp.subCharIndex = charIndex;
-                                    _charPositions.Add(cp);
+                                    CharPosition cp = _charPositions[_charPositions.Count - 1];
+                                    cp.drawLineSubIndex = (short)(maxSubTextIndexInLine + 1);
+                                    cp.drawLineSubStartCharIndex = charIndex;
+                                    cp.drawLineCount = 1;
+                                    _charPositions[_charPositions.Count - 1] = cp;
                                 }
                             }
 #endif
@@ -1556,17 +1555,22 @@ namespace FairyGUI
                             }
                             else
                             {
-                                int charIndex = _subTextFields[maxSubTextIndexInLine].AddToRendererLine(1, (short)i, strikethroughStart < posx ? strikethroughStart : posx, -(line.y + line.baseline), lineWidth,
-                                    minFontSize);
-                                // Add line
+                                int charIndex = _subTextFields[maxSubTextIndexInLine].AddToRendererLine(1,
+                                    strikethroughStart < posx ? strikethroughStart : posx, -(line.y + line.baseline), lineWidth, minFontSize);
+                                // line
                                 if (_charPositions != null)
                                 {
-                                    CharPosition cp = new CharPosition();
-                                    cp.drawLineBySub = true;
-                                    cp.lineIndex = (short)i;
-                                    cp.subIndex = (short)(maxSubTextIndexInLine + 1);
-                                    cp.subCharIndex = charIndex;
-                                    _charPositions.Add(cp);
+                                    CharPosition cp = _charPositions[_charPositions.Count - 1];
+                                    if (cp.lineIndex == (short) i && cp.drawLineSubIndex == (short) (maxSubTextIndexInLine + 1) &&
+                                        cp.drawLineSubStartCharIndex == charIndex - cp.drawLineCount)
+                                        cp.drawLineCount++;
+                                    else
+                                    {
+                                        cp.drawLineSubIndex = (short)(maxSubTextIndexInLine + 1);
+                                        cp.drawLineSubStartCharIndex = charIndex;
+                                        cp.drawLineCount = 1;
+                                    }
+                                    _charPositions[_charPositions.Count - 1] = cp;
                                 }
                             }
 #endif
@@ -1903,11 +1907,6 @@ namespace FairyGUI
             
 #if FAIRYGUI_TMPRO
             /// <summary>
-            /// 是否使用submesh绘制line
-            /// </summary>
-            public bool drawLineBySub;
-            
-            /// <summary>
             /// 大于0表示使用submesh
             /// </summary>
             public short subIndex;
@@ -1916,6 +1915,22 @@ namespace FairyGUI
             /// submesh的字符索引
             /// </summary>
             public int subCharIndex;
+            
+                        
+            /// <summary>
+            /// 大于0表示使用submesh绘制line
+            /// </summary>
+            public short drawLineSubIndex;
+            
+            /// <summary>
+            /// 绘制line的submesh的line起始字符索引
+            /// </summary>
+            public int drawLineSubStartCharIndex;
+
+            /// <summary>
+            /// 绘制line的数量
+            /// </summary>
+            public byte drawLineCount;
 #endif
         }
     }

--- a/Assets/Scripts/Core/Text/TextField.cs
+++ b/Assets/Scripts/Core/Text/TextField.cs
@@ -432,6 +432,46 @@ namespace FairyGUI
             get { return _richTextField; }
         }
 
+#if FAIRYGUI_TMPRO
+        /// <summary>
+        /// 
+        /// </summary>
+        override public Material material
+        {
+            get
+            {
+                if (graphics != null)
+                    return graphics.material;
+                else
+                    return null;
+            }
+            set
+            {
+                if (graphics != null)
+                    graphics.material = value;
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        override public string shader
+        {
+            get
+            {
+                if (graphics != null)
+                    return graphics.shader;
+                else
+                    return null;
+            }
+            set
+            {
+                if (graphics != null)
+                    graphics.shader = value;
+            }
+        }
+#endif
+        
         /// <summary>
         /// 
         /// </summary>

--- a/Assets/Scripts/Core/Text/TypingEffect.cs
+++ b/Assets/Scripts/Core/Text/TypingEffect.cs
@@ -17,6 +17,7 @@ namespace FairyGUI
         protected List<int> _strokeLayerStartList = new List<int>();
         protected List<int> _vertIndexList = new List<int>();
         protected List<int> _mainLayerVertCountList = new List<int>();
+        protected int _printSubLineCount;
 #else
         protected Vector3[] _backupVerts;
         protected Vector3[] _vertices;
@@ -93,6 +94,7 @@ namespace FairyGUI
             _started = true;
 
 #if FAIRYGUI_TMPRO
+            _printSubLineCount = 0;
             int vertCount = 0;
             int meshVertCount = 0;
             _backupVertsList.Clear();
@@ -224,8 +226,16 @@ namespace FairyGUI
             {
                 cp = charPositions[_printIndex++];
 #if FAIRYGUI_TMPRO
+                // Next is underline or strikethrough, continue print.
+                bool continuePrint = _printIndex < listCnt - 1 && charPositions[_printIndex].drawLineBySub;
+                bool isPrintLine = false;
                 if (cp.vertCount > 0 || cp.subIndex > 0)
                 {
+                    if (cp.drawLineBySub)
+                    {
+                        isPrintLine = true;
+                        _printSubLineCount++;
+                    }
                     int vertCount = cp.subIndex > 0 ? _textField.GetSubTextField(cp.subIndex - 1).toRendererChars[cp.subCharIndex].vertCount : cp.vertCount;
                     if (vertCount > 0)
                         output(vertCount, cp.subIndex);
@@ -237,10 +247,19 @@ namespace FairyGUI
                 if (cp.imgIndex > 0) //这是一个图片
                 {
                     _textField.richTextField.ShowHtmlObject(cp.imgIndex - 1, true);
-                    return true;
+#if FAIRYGUI_TMPRO
+                    if (!continuePrint)
+#endif
+                        return true;
                 }
+#if FAIRYGUI_TMPRO
+                else if (isPrintLine || !char.IsWhiteSpace(_textField.parsedText[_printIndex - 1 - _printSubLineCount]))
+                    if (!continuePrint)
+                        return true;
+#else
                 else if (!char.IsWhiteSpace(_textField.parsedText[_printIndex - 1]))
                     return true;
+#endif
             }
 
             Cancel();

--- a/Assets/Scripts/Core/Text/TypingEffect.cs
+++ b/Assets/Scripts/Core/Text/TypingEffect.cs
@@ -170,9 +170,9 @@ namespace FairyGUI
                 }
                 else
                 {
-                    var toRendererChars = _textField.GetSubTextField(i - 1).toRendererChars;
-                    for (int j = 0, count = toRendererChars.Count; j < count; j++)
-                        mainLayerVertCount  += toRendererChars[j].vertCount;
+                    var verticesCount = _textField.GetSubTextField(i - 1).VerticesCount;
+                    for (int j = 0, count = verticesCount.Count; j < count; j++)
+                        mainLayerVertCount  += verticesCount[j];
                 }
                 _mainLayerVertCountList.Add(mainLayerVertCount);
                 if (mainLayerVertCount < meshVertCount) //说明有描边或者阴影
@@ -235,7 +235,7 @@ namespace FairyGUI
 #if FAIRYGUI_TMPRO
                 if (cp.vertCount > 0 || cp.subIndex > 0)
                 {
-                    int vertCount = cp.subIndex > 0 ? _textField.GetSubTextField(cp.subIndex - 1).toRendererChars[cp.subCharIndex].vertCount : cp.vertCount;
+                    int vertCount = cp.subIndex > 0 ? _textField.GetSubTextField(cp.subIndex - 1).VerticesCount[cp.subCharIndex] : cp.vertCount;
                     if (vertCount > 0)
                         output(vertCount, cp.subIndex);
                 }
@@ -243,10 +243,10 @@ namespace FairyGUI
                 // Draw lines
                 if (cp.drawLineSubIndex > 0)
                 {
-                    var toRendererChars = _textField.GetSubTextField(cp.drawLineSubIndex - 1).toRendererChars;
+                    var verticesCount = _textField.GetSubTextField(cp.drawLineSubIndex - 1).VerticesCount;
                     for (byte i = 0, count = cp.drawLineCount; i < count; i++)
                     {
-                        int vertCount = toRendererChars[cp.drawLineSubStartCharIndex + i].vertCount;
+                        int vertCount = verticesCount[cp.drawLineSubStartCharIndex + i];
                         if (vertCount > 0)
                             output(vertCount, cp.drawLineSubIndex);
                     }

--- a/Assets/Scripts/Core/Text/TypingEffect.cs
+++ b/Assets/Scripts/Core/Text/TypingEffect.cs
@@ -10,18 +10,27 @@ namespace FairyGUI
     public class TypingEffect
     {
         protected TextField _textField;
+#if FAIRYGUI_TMPRO
+        protected List<Vector3[]> _backupVertsList = new List<Vector3[]>();
+        protected Vector3[][] _verticesList;
+        protected List<int> _mainLayerStartList = new List<int>();
+        protected List<int> _strokeLayerStartList = new List<int>();
+        protected List<int> _vertIndexList = new List<int>();
+        protected List<int> _mainLayerVertCountList = new List<int>();
+#else
         protected Vector3[] _backupVerts;
         protected Vector3[] _vertices;
+        protected int _mainLayerStart;
+        protected int _strokeLayerStart;
+        protected int _vertIndex;
+        protected int _mainLayerVertCount;
+#endif
 
         protected bool _stroke;
         protected bool _shadow;
 
         protected int _printIndex;
-        protected int _mainLayerStart;
-        protected int _strokeLayerStart;
         protected int _strokeDrawDirs;
-        protected int _vertIndex;
-        protected int _mainLayerVertCount;
 
         protected bool _started;
 
@@ -80,12 +89,42 @@ namespace FairyGUI
             _stroke = false;
             _shadow = false;
             _strokeDrawDirs = 4;
-            _mainLayerStart = 0;
-            _mainLayerVertCount = 0;
             _printIndex = 0;
-            _vertIndex = 0;
             _started = true;
 
+#if FAIRYGUI_TMPRO
+            int vertCount = 0;
+            int meshVertCount = 0;
+            _backupVertsList.Clear();
+            _mainLayerStartList.Clear();
+            _strokeLayerStartList.Clear();
+            _vertIndexList.Clear();
+            _mainLayerVertCountList.Clear();
+            if (_verticesList == null || _verticesList.Length < _textField.activeSubMeshCount + 1)
+                _verticesList = new Vector3[_textField.activeSubMeshCount + 1][];
+            for (int i = 0, count = _textField.activeSubMeshCount + 1; i < count; i++)
+            {
+                _vertIndexList.Add(0);
+                var displayObject = _textField.GetChildAt(i);
+                meshVertCount = displayObject.graphics.mesh.vertexCount;
+                vertCount += meshVertCount;
+                var backupVerts = displayObject.graphics.mesh.vertices;
+                _backupVertsList.Add(backupVerts);
+                Vector3[] vertices = _verticesList[i];
+                if (vertices == null || vertices.Length < meshVertCount)
+                {
+                    vertices = new Vector3[meshVertCount];
+                    _verticesList[i] = vertices;
+                }
+                Vector3 zero = Vector3.zero;
+                for (int j = 0; j < meshVertCount; j++)
+                    vertices[j] = zero;
+                displayObject.graphics.mesh.vertices = vertices;
+            }
+#else
+            _mainLayerStart = 0;
+            _mainLayerVertCount = 0;
+            _vertIndex = 0;
             int vertCount = _textField.graphics.mesh.vertexCount;
             _backupVerts = _textField.graphics.mesh.vertices;
             if (_vertices == null || _vertices.Length != vertCount)
@@ -94,6 +133,7 @@ namespace FairyGUI
             for (int i = 0; i < vertCount; i++)
                 _vertices[i] = zero;
             _textField.graphics.mesh.vertices = _vertices;
+#endif
 
             //隐藏所有混排的对象
             if (_textField.richTextField != null)
@@ -103,6 +143,51 @@ namespace FairyGUI
                     _textField.richTextField.ShowHtmlObject(i, false);
             }
 
+#if FAIRYGUI_TMPRO
+            int allMainLayerVertCount = 0;
+            for (int i = 0, childCount = _textField.activeSubMeshCount + 1; i < childCount; i++)
+            {
+                var displayObject = _textField.GetChildAt(i);
+                meshVertCount = displayObject.graphics.mesh.vertexCount;
+                int mainLayerVertCount = 0;
+                if (i == 0)
+                {
+                    int charCount = _textField.charPositions.Count;
+                    for (int j = 0; j < charCount; j++)
+                    {
+                        TextField.CharPosition cp = _textField.charPositions[j];
+                        mainLayerVertCount += cp.vertCount;
+                    }
+                }
+                else
+                {
+                    var toRendererChars = _textField.GetSubTextField(i - 1).toRendererChars;
+                    for (int j = 0, count = toRendererChars.Count; j < count; j++)
+                        mainLayerVertCount  += toRendererChars[j].vertCount;
+                }
+                _mainLayerVertCountList.Add(mainLayerVertCount);
+                if (mainLayerVertCount < meshVertCount) //说明有描边或者阴影
+                {
+                    int repeat = meshVertCount / mainLayerVertCount;
+                    _mainLayerStartList.Add(meshVertCount - meshVertCount / repeat);
+                    _strokeLayerStartList.Add(repeat % 2 == 0 ? (meshVertCount / repeat) : 0);
+                }
+                else
+                {
+                    _mainLayerStartList.Add(0);
+                    _strokeLayerStartList.Add(0);
+                }
+                allMainLayerVertCount += mainLayerVertCount;
+            }
+            
+            if (allMainLayerVertCount < vertCount) //说明有描边或者阴影
+            {
+                int repeat = vertCount / allMainLayerVertCount;
+                _stroke = repeat > 2;
+                _shadow = repeat % 2 == 0;
+                _strokeDrawDirs = repeat > 8 ? 8 : 4;
+            }
+#else
             int charCount = _textField.charPositions.Count;
             for (int i = 0; i < charCount; i++)
             {
@@ -119,6 +204,7 @@ namespace FairyGUI
                 _strokeLayerStart = _shadow ? (vertCount / repeat) : 0;
                 _strokeDrawDirs = repeat > 8 ? 8 : 4;
             }
+#endif
         }
 
         /// <summary>
@@ -137,8 +223,17 @@ namespace FairyGUI
             while (_printIndex < listCnt - 1) //最后一个是占位的，无效的，所以-1
             {
                 cp = charPositions[_printIndex++];
+#if FAIRYGUI_TMPRO
+                if (cp.vertCount > 0 || cp.subIndex > 0)
+                {
+                    int vertCount = cp.subIndex > 0 ? _textField.GetSubTextField(cp.subIndex - 1).toRendererChars[cp.subCharIndex].vertCount : cp.vertCount;
+                    if (vertCount > 0)
+                        output(vertCount, cp.subIndex);
+                }
+#else
                 if (cp.vertCount > 0)
                     output(cp.vertCount);
+#endif
                 if (cp.imgIndex > 0) //这是一个图片
                 {
                     _textField.richTextField.ShowHtmlObject(cp.imgIndex - 1, true);
@@ -152,6 +247,51 @@ namespace FairyGUI
             return false;
         }
 
+#if FAIRYGUI_TMPRO
+        private void output(int vertCount, int subIndex)
+        {
+            int start, end;
+
+            var mainLayerStart = _mainLayerStartList[subIndex];
+            var vertIndex = _vertIndexList[subIndex];
+            var vertices = _verticesList[subIndex];
+            var backupVerts = _backupVertsList[subIndex];
+            var strokeLayerStart = _strokeLayerStartList[subIndex];
+            var mainLayerVertCount = _mainLayerVertCountList[subIndex];
+            start = mainLayerStart + vertIndex;
+            end = start + vertCount;
+            for (int i = start; i < end; i++)
+                vertices[i] = backupVerts[i];
+
+            if (_stroke)
+            {
+                start = strokeLayerStart + vertIndex;
+                end = start + vertCount;
+                for (int i = start; i < end; i++)
+                {
+                    for (int j = 0; j < _strokeDrawDirs; j++)
+                    {
+                        int k = i + mainLayerVertCount * j;
+                        vertices[k] = backupVerts[k];
+                    }
+                }
+            }
+
+            if (_shadow)
+            {
+                start = vertIndex;
+                end = start + vertCount;
+                for (int i = start; i < end; i++)
+                {
+                    vertices[i] = backupVerts[i];
+                }
+            }
+
+            _textField.GetChildAt(subIndex).graphics.mesh.vertices = vertices;
+
+            _vertIndexList[subIndex] = vertIndex + vertCount;
+        }
+#else
         private void output(int vertCount)
         {
             int start, end;
@@ -189,6 +329,7 @@ namespace FairyGUI
 
             _vertIndex += vertCount;
         }
+#endif
 
         /// <summary>
         /// 打印的协程。
@@ -217,7 +358,7 @@ namespace FairyGUI
 
             _started = false;
             _textField.graphics.meshModifier -= OnMeshModified;
-            _textField.graphics.SetMeshDirty();
+            _textField.SetMeshDirty();
         }
 
         /// <summary>
@@ -226,6 +367,33 @@ namespace FairyGUI
         /// </summary>
         void OnMeshModified()
         {
+#if FAIRYGUI_TMPRO
+            for (int i = 0, count = _backupVertsList.Count; i < count; i++)
+            {
+                if (_textField.GetChildAt(i).graphics.mesh.vertexCount != _backupVertsList[i].Length) //可能文字都改了
+                {
+                    Cancel();
+                    return;
+                }
+            }
+
+            _backupVertsList.Clear();
+            for (int i = 0, count = _textField.activeSubMeshCount + 1; i < count; i++)
+            {
+                var displayObject = _textField.GetChildAt(i);
+                var backupVerts = displayObject.graphics.mesh.vertices;
+                _backupVertsList.Add(backupVerts);
+                var vertices = _verticesList[i];
+                Vector3 zero = Vector3.zero;
+                for (int j = 0, len = vertices.Length; j < len; j++)
+                {
+                    if (vertices[j] != zero)
+                        vertices[j] = backupVerts[j];
+                }
+
+                displayObject.graphics.mesh.vertices = vertices;
+            }
+#else
             if (_textField.graphics.mesh.vertexCount != _backupVerts.Length) //可能文字都改了
             {
                 Cancel();
@@ -243,6 +411,7 @@ namespace FairyGUI
             }
 
             _textField.graphics.mesh.vertices = _vertices;
+#endif
         }
     }
 }


### PR DESCRIPTION
支持TextMeshPro的字体fallback功能。如下图所示：
不同字体会生成不同的Mesh去渲染。支持TypingEffect、下划线、删除线。
![image](https://github.com/fairygui/FairyGUI-unity/assets/45276696/422f3fc2-7d38-4c98-96f9-d7587a46fbf4)

注：TextMeshPro插件本身对fallback 的情况下的下划线、删除线的支持不友好，渲染层级有错误，如图所示：
![image](https://github.com/fairygui/FairyGUI-unity/assets/45276696/73cf3b21-442c-4b68-84a6-df4461ea89e1)
但是在FGUI的支持里修复了这个问题。

注：对TextMeshPro插件版本有要求，2.0.1版本不支持。测试了2.1.6及其以上是支持的。没有测试最低版本是多少