### PR TITLE
fix:当子物体修改了锚点时,父物体计算Bound时添加对锚点的偏移

### DIFF
--- a/Assets/Scripts/UI/GComponent.cs
+++ b/Assets/Scripts/UI/GComponent.cs
@@ -1172,10 +1172,10 @@ namespace FairyGUI
                     tmp = child.y;
                     if (tmp < ay)
                         ay = tmp;
-                    tmp = child.x + child.actualWidth;
+                    tmp = child.x + (child.pivotAsAnchor ? child.actualWidth * (1 - child.pivot.x) : child.actualWidth);//Add anchor offset
                     if (tmp > ar)
                         ar = tmp;
-                    tmp = child.y + child.actualHeight;
+                    tmp = child.y + (child.pivotAsAnchor ? child.actualHeight * (1 - child.pivot.y) : child.actualHeight);//Add anchor offset
                     if (tmp > ab)
                         ab = tmp;
                 }


### PR DESCRIPTION
当父组件开启了滚动,并且子物体修改了锚点,在计算Bound时会把所有子物体当作锚点在(0,0)的情况下计算,如果当子物体放在最右边时,在游戏中的效果就会变成右边会多出来一块子物体设置的锚点对应大小的空间,在UpdateBound中加上了锚点对应的偏移就正常了.

修改前的例子:
![image](https://github.com/fairygui/FairyGUI-unity/assets/45478238/3c55b305-7bd1-4709-88c9-7726da9cad56)

![image](https://github.com/fairygui/FairyGUI-unity/assets/45478238/517f7ad1-9e00-4bd9-9c75-0afdda93f4a0)

![image](https://github.com/fairygui/FairyGUI-unity/assets/45478238/b319ac08-e076-437b-a46f-28f53b1db6bc)

修改后的例子:
![image](https://github.com/fairygui/FairyGUI-unity/assets/45478238/d42669ba-29c6-431b-9731-c4ffdfa6c678)


![llz4q-szteo](https://github.com/fairygui/FairyGUI-unity/assets/45478238/c52e5c81-c9e8-4439-a22e-5e9aa0540162)
