### PR TITLE
GLoader 内放组件时支持调整其尺寸进行适配

### DIFF
--- a/Assets/Scripts/UI/FieldTypes.cs
+++ b/Assets/Scripts/UI/FieldTypes.cs
@@ -66,7 +66,8 @@
         ScaleMatchHeight,
         ScaleMatchWidth,
         ScaleFree,
-        ScaleNoBorder
+        ScaleNoBorder,
+        Resize = ScaleFree,
     }
 
     public enum AutoSizeType

--- a/Assets/Scripts/UI/GLoader.cs
+++ b/Assets/Scripts/UI/GLoader.cs
@@ -537,6 +537,13 @@ namespace FairyGUI
                 return;
             }
 
+            if (_fill == FillType.Resize && _content2 != null)
+            {
+                sourceWidth = (int)width;
+                sourceHeight = (int)height;
+                _content2.SetSize(sourceWidth, sourceHeight);
+            }
+
             float contentWidth = sourceWidth;
             float contentHeight = sourceHeight;
 


### PR DESCRIPTION
GLoader 的 FillType 新增 Resize 模式，由于现在FairyGUI编辑器不支持此类适配模式，这里先将其取值设置为与自由缩放相等，这样在编辑器中可以先凑活用。

已经在 Laya 的 SDK 中这样修改并应用与多款游戏项目。

用例：
将 GLoader 作为页面容器，通过修改 url 实现类似前端路由切换页面的功能。