### PR TITLE
修复在微信IOS小游戏下拖拽无效的Bug

### DIFF
--- a/Assets/Scripts/Core/Stage.cs
+++ b/Assets/Scripts/Core/Stage.cs
@@ -130,6 +130,7 @@ namespace FairyGUI
 #endif
                     _clickTestThreshold = 50;
                     _touchSupportDetected = true;
+                    inst.ResetInputState();
                 }
                 else
                 {
@@ -876,7 +877,7 @@ namespace FairyGUI
 
                     TouchInfo touch = null;
                     TouchInfo free = null;
-                    for (int j = 0; j < 5; j++)
+                    for (int j = 4; j >= 0; j--)
                     {
                         if (_touches[j].touchId == touchId)
                         {


### PR DESCRIPTION
在StartDrag(-1)中默认从0开始搜索未被使用的TouchInfo.而Stage.GetHitTarget中.则是使用最后一个未被使用的TouchInfo.两边逻辑未统一