### PR TITLE
Avoid hitting test on invalid positions

### DIFF
--- a/Assets/Scripts/Core/Stage.cs
+++ b/Assets/Scripts/Core/Stage.cs
@@ -917,7 +917,9 @@ namespace FairyGUI
 #endif
                 pos.y = Screen.height - pos.y;
                 TouchInfo touch = _touches[0];
-                if (pos.x < 0 || pos.y < 0) // outside of the window
+                if (float.IsNaN(pos.x) || float.IsNaN(pos.y) || float.IsInfinity(pos.x) || float.IsInfinity(pos.y)) //not a valid position
+                    _touchTarget = this;
+                else if (pos.x < 0 || pos.y < 0) // outside of the window
                     _touchTarget = this;
                 else
                     _touchTarget = HitTest(pos, true);


### PR DESCRIPTION
When starting the example scene I found the error messages like this filling up the console

Screen position out of view frustum (screen pos inf, -inf, 0.000000) (Camera rect 0 0 1536 2048)

here's a quick fix by avoiding test on these positions