### PR TITLE
Fix rendering order error

### DIFF
--- a/Assets/Scripts/Core/CaptureCamera.cs
+++ b/Assets/Scripts/Core/CaptureCamera.cs
@@ -180,7 +180,7 @@ namespace FairyGUI
             if (target.graphics != null)
             {
                 oldLayer = target.graphics.gameObject.layer;
-                target.graphics.gameObject.layer = CaptureCamera.layer;
+                target._SetLayerDirect(CaptureCamera.layer);
             }
 
             if (target is Container)
@@ -196,7 +196,7 @@ namespace FairyGUI
             RenderTexture.active = old;
 
             if (target.graphics != null)
-                target.graphics.gameObject.layer = oldLayer;
+                target._SetLayerDirect(oldLayer);
 
             if (target is Container)
                 ((Container)target).SetChildrenLayer(oldLayer);

--- a/Assets/Scripts/Core/GoWrapper.cs
+++ b/Assets/Scripts/Core/GoWrapper.cs
@@ -280,6 +280,7 @@ namespace FairyGUI
                     }
                 }
             }
+            context.renderingOrder++;
         }
 
         public override BatchElement AddToBatch(List<BatchElement> batchElements, bool force)

--- a/Assets/Scripts/Core/NGraphics.cs
+++ b/Assets/Scripts/Core/NGraphics.cs
@@ -471,6 +471,12 @@ namespace FairyGUI
             {
                 _vertexMatrix = value;
                 _meshDirty = true;
+                
+                if (subInstances != null)
+                {
+                    foreach (var sub in subInstances)
+                        sub._vertexMatrix = value;
+                }
             }
         }
 
@@ -835,7 +841,9 @@ namespace FairyGUI
             newGameObject.transform.SetParent(gameObject.transform, false);
             newGameObject.layer = gameObject.layer;
             newGameObject.hideFlags = gameObject.hideFlags;
-            return new NGraphics(newGameObject);
+            var newGraphics = new NGraphics(newGameObject);
+            newGraphics._vertexMatrix = _vertexMatrix;
+            return newGraphics;
         }
 
         class StencilEraser

--- a/Assets/Scripts/Core/NGraphics.cs
+++ b/Assets/Scripts/Core/NGraphics.cs
@@ -383,13 +383,13 @@ namespace FairyGUI
 
         public void SetRenderingOrder(UpdateContext context, bool inBatch)
         {
-            meshRenderer.sortingOrder = ++context.renderingOrder;
+            meshRenderer.sortingOrder = context.renderingOrder++;
 
             if (subInstances != null && !inBatch)
             {
                 foreach (var sub in subInstances)
                 {
-                    sub.meshRenderer.sortingOrder = ++context.renderingOrder;
+                    sub.meshRenderer.sortingOrder = context.renderingOrder++;
                 }
             }
         }

--- a/Assets/Scripts/Core/NGraphics.cs
+++ b/Assets/Scripts/Core/NGraphics.cs
@@ -383,13 +383,13 @@ namespace FairyGUI
 
         public void SetRenderingOrder(UpdateContext context, bool inBatch)
         {
-            meshRenderer.sortingOrder = context.renderingOrder++;
+            meshRenderer.sortingOrder = ++context.renderingOrder;
 
             if (subInstances != null && !inBatch)
             {
                 foreach (var sub in subInstances)
                 {
-                    sub.meshRenderer.sortingOrder = context.renderingOrder++;
+                    sub.meshRenderer.sortingOrder = ++context.renderingOrder;
                 }
             }
         }


### PR DESCRIPTION
If the previous element is a GoWrapper and the next element is an Image, it will cause their sortingOrder to be the same.