### PR TITLE
修复使用TextMeshPro 在SoftClip 裁剪区域的半透明问题

### DIFF
--- a/Assets/Resources/Shaders/FairyGUI-BMFont.shader
+++ b/Assets/Resources/Shaders/FairyGUI-BMFont.shader
@@ -49,8 +49,8 @@ Shader "FairyGUI/BMFont"
         Pass
         {
             CGPROGRAM
-                #pragma multi_compile NOT_GRAYED GRAYED
-                #pragma multi_compile NOT_CLIPPED CLIPPED SOFT_CLIPPED
+                #pragma multi_compile _ GRAYED
+                #pragma multi_compile _ CLIPPED SOFT_CLIPPED
                 #pragma vertex vert
                 #pragma fragment frag
                 #pragma exclude_renderers d3d9 opengl flash
@@ -127,28 +127,22 @@ Shader "FairyGUI/BMFont"
                     #endif
 
                     #ifdef SOFT_CLIPPED
-                    float2 factor = float2(0,0);
-                    if(i.clipPos.x<0)
-                        factor.x = (1.0-abs(i.clipPos.x)) * _ClipSoftness.x;
-                    else
-                        factor.x = (1.0-i.clipPos.x) * _ClipSoftness.z;
-                    if(i.clipPos.y<0)
-                        factor.y = (1.0-abs(i.clipPos.y)) * _ClipSoftness.w;
-                    else
-                        factor.y = (1.0-i.clipPos.y) * _ClipSoftness.y;
+		            float2 factor;
+		            float2 condition = step(i.clipPos.xy, 0);
+		            float4 clip_softness = _ClipSoftness * float4(condition, 1 - condition);
+		            factor.xy = (1.0 - abs(i.clipPos.xy)) * (clip_softness.xw + clip_softness.zy);
                     col.a *= clamp(min(factor.x, factor.y), 0.0, 1.0);
                     #endif
-
                     #ifdef CLIPPED
                     float2 factor = abs(i.clipPos);
                     col.a *= step(max(factor.x, factor.y), 1);
                     #endif
 
                     return col;
-                }
+            }
             ENDCG
         }
     }
 
-    Fallback "FairyGUI/Text"
+    //Fallback "FairyGUI/Text"
 }

--- a/Assets/Resources/Shaders/FairyGUI-Image.shader
+++ b/Assets/Resources/Shaders/FairyGUI-Image.shader
@@ -49,9 +49,9 @@ Shader "FairyGUI/Image"
         Pass
         {
             CGPROGRAM
-                #pragma multi_compile NOT_COMBINED COMBINED
-                #pragma multi_compile NOT_GRAYED GRAYED COLOR_FILTER
-                #pragma multi_compile NOT_CLIPPED CLIPPED SOFT_CLIPPED ALPHA_MASK
+                #pragma multi_compile _ COMBINED
+                #pragma multi_compile _ GRAYED COLOR_FILTER
+                #pragma multi_compile _ CLIPPED SOFT_CLIPPED ALPHA_MASK
                 #pragma vertex vert
                 #pragma fragment frag
                 
@@ -139,15 +139,10 @@ Shader "FairyGUI/Image"
                     #endif
 
                     #ifdef SOFT_CLIPPED
-                    float2 factor = float2(0,0);
-                    if(i.clipPos.x<0)
-                        factor.x = (1.0-abs(i.clipPos.x)) * _ClipSoftness.x;
-                    else
-                        factor.x = (1.0-i.clipPos.x) * _ClipSoftness.z;
-                    if(i.clipPos.y<0)
-                        factor.y = (1.0-abs(i.clipPos.y)) * _ClipSoftness.w;
-                    else
-                        factor.y = (1.0-i.clipPos.y) * _ClipSoftness.y;
+		            float2 factor;
+		            float2 condition = step(i.clipPos.xy, 0);
+		            float4 clip_softness = _ClipSoftness * float4(condition, 1 - condition);
+		            factor.xy = (1.0 - abs(i.clipPos.xy)) * (clip_softness.xw + clip_softness.zy);
                     col.a *= clamp(min(factor.x, factor.y), 0.0, 1.0);
                     #endif
 

--- a/Assets/Resources/Shaders/FairyGUI-Text.shader
+++ b/Assets/Resources/Shaders/FairyGUI-Text.shader
@@ -49,8 +49,8 @@ Shader "FairyGUI/Text"
         Pass
         {
             CGPROGRAM
-                #pragma multi_compile NOT_GRAYED GRAYED
-                #pragma multi_compile NOT_CLIPPED CLIPPED SOFT_CLIPPED
+                #pragma multi_compile _ GRAYED
+                #pragma multi_compile _ CLIPPED SOFT_CLIPPED
                 #pragma vertex vert
                 #pragma fragment frag
 
@@ -125,15 +125,10 @@ Shader "FairyGUI/Text"
                     #endif
 
                     #ifdef SOFT_CLIPPED
-                    float2 factor = float2(0,0);
-                    if(i.clipPos.x<0)
-                        factor.x = (1.0-abs(i.clipPos.x)) * _ClipSoftness.x;
-                    else
-                        factor.x = (1.0-i.clipPos.x) * _ClipSoftness.z;
-                    if(i.clipPos.y<0)
-                        factor.y = (1.0-abs(i.clipPos.y)) * _ClipSoftness.w;
-                    else
-                        factor.y = (1.0-i.clipPos.y) * _ClipSoftness.y;
+		            float2 factor;
+		            float2 condition = step(i.clipPos.xy, 0);
+		            float4 clip_softness = _ClipSoftness * float4(condition, 1 - condition);
+		            factor.xy = (1.0 - abs(i.clipPos.xy)) * (clip_softness.xw + clip_softness.zy);
                     col.a *= clamp(min(factor.x, factor.y), 0.0, 1.0);
                     #endif
 


### PR DESCRIPTION
修复使用TextMeshPro 在SoftClip 裁剪区域的半透明问题
修改 SOFT_CLIPPED 相关计算
减少 shader 变体 &去掉无意义的FallBack