### PR TITLE
GoWrapper 与 Mask因为开启SRPBatcher可能渲染顺序错误

### DIFF
--- a/Assets/Scripts/Core/GoWrapper.cs
+++ b/Assets/Scripts/Core/GoWrapper.cs
@@ -279,6 +279,8 @@ namespace FairyGUI
                         ri.renderer.sortingOrder = value;
                     }
                 }
+                if (cnt > 0)
+                    context.renderingOrder++;
             }
         }
 


### PR DESCRIPTION
GoWrapper SetRenderingOrder后，context RenderOrder未+1。会出现 WriteStencil(order=1), GoWrapper(order=2),EraseStencil(order=2)。开启SRPBatcher出现 WriteMask->EraseStencil->GoWrapper情况