### PR TITLE
fix ArgumentOutOfRangeException when richtextfield._textChanged is true

### DIFF
--- a/Assets/Scripts/Core/Container.cs
+++ b/Assets/Scripts/Core/Container.cs
@@ -942,6 +942,7 @@ namespace FairyGUI
 
         private void CollectChildren(Container initiator, bool outlineChanged)
         {
+            EnsureSizeCorrect();
             int count = _children.Count;
             for (int i = 0; i < count; i++)
             {


### PR DESCRIPTION
修复 https://github.com/fairygui/FairyGUI-unity/issues/241 这个issue所描述的问题

RichTextField/TextField在OnUpdate的时候触发了OnSizeChanged, 到上层需要BatchUpdate的节点执行SetRenderingOrder时，因为此时的_textChanged是true, 所以会在
Rect rect = child.GetBounds(initiator);
时触发EnsureSizeCorrect()，将所有的同级节点都移除，导致

            int count = _children.Count;
            for (int i = 0; i < count; i++)
count发生了变化，但是这里的值时旧的，会 throw OutOfRange Exception