### PR TITLE
修复：WebGL 下的 InputField

### DIFF
--- a/Assets/Scripts/Core/Stage.cs
+++ b/Assets/Scripts/Core/Stage.cs
@@ -125,7 +125,7 @@ namespace FairyGUI
                 _touchScreen = value;
                 if (_touchScreen)
                 {
-#if !(UNITY_WEBPLAYER || UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_EDITOR)
+#if !(UNITY_WEBGL || UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_EDITOR)
                     keyboardInput = true;
 #endif
                     _clickTestThreshold = 50;
@@ -154,7 +154,7 @@ namespace FairyGUI
                 _keyboardInput = value;
                 if (value && _keyboard == null)
                 {
-#if !(UNITY_WEBPLAYER || UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_EDITOR)
+#if !(UNITY_WEBGL || UNITY_STANDALONE_WIN || UNITY_STANDALONE_OSX || UNITY_EDITOR)
                     _keyboard = new TouchScreenKeyboard();
 #endif
                 }

--- a/Assets/Scripts/Extensions/WebGLTextInput/WebGLTextInput.cs
+++ b/Assets/Scripts/Extensions/WebGLTextInput/WebGLTextInput.cs
@@ -15,32 +15,26 @@ public static class WebGLTextInput
 
     public static void Start(InputTextField target)
     {
-        WebGLTextInputSetText(target.text,
+        var rect = target.TransformRect(new Rect(0, 0, target.width, target.height), null);
+        rect.min = StageCamera.main.WorldToScreenPoint(rect.min);
+        rect.max = StageCamera.main.WorldToScreenPoint(rect.max);
+        rect.y = Screen.height - rect.y - rect.height;
+
+        WebGLTextInputShow(rect.x, rect.y, target.width, target.height, rect.width / target.width, rect.height / target.height, target.text,
             !target.textField.singleLine,
             ColorUtility.ToHtmlStringRGBA(target.textFormat.color),
             target.textFormat.size,
             target.textFormat.font,
-            target.maxLength);
-
+            target.maxLength,
+            target.textFormat.align,
+            target.textFormat.lineSpacing);
+        
         WebGLInput.captureAllKeyboardInput = false;
-
-        SyncTransform(target);
     }
 
     public static void Stop()
     {
         WebGLTextInputHide();
-    }
-
-    public static void SyncTransform(InputTextField target)
-    {
-        Rect rect = target.TransformRect(new Rect(0, 0, target.width, target.height), null);
-        rect.min = StageCamera.main.WorldToScreenPoint(rect.min);
-        rect.max = StageCamera.main.WorldToScreenPoint(rect.max);
-        rect.y = Screen.height - rect.y - rect.height;
-
-        WebGLTextInputShow(rect.x, rect.y, target.width, target.height,
-            rect.width / target.width, rect.height / target.height);
     }
 
     [MonoPInvokeCallback(typeof(Action<string>))]
@@ -65,10 +59,8 @@ public static class WebGLTextInput
     public static extern void WebGLTextInputInit(Action<string> onInputCallback, Action onBlurCallback);
 
     [DllImport("__Internal")]
-    public static extern void WebGLTextInputSetText(string text, bool multiline, string color, int fontSize, string fontFace, int maxLength);
-
-    [DllImport("__Internal")]
-    public static extern void WebGLTextInputShow(float x, float y, float width, float height, float scaleX, float scaleY);
+    public static extern void WebGLTextInputShow(float x, float y, float width, float height, float scaleX, float scaleY, string text, bool multiline, string color, int fontSize,
+        string fontFace, int maxLength, AlignType align, int lineSpacing);
 
     [DllImport("__Internal")]
     public static extern void WebGLTextInputHide();

--- a/Assets/Scripts/Extensions/WebGLTextInput/WebGLTextInput.jslib
+++ b/Assets/Scripts/Extensions/WebGLTextInput/WebGLTextInput.jslib
@@ -10,7 +10,7 @@ var WebGLTextInput = {
         canvasEle = document.getElementById('unity-canvas');
     },
 
-    WebGLTextInputSetText: function (text, multiline, color, fontSize, fontFace, maxLength) {
+    WebGLTextInputShow: function (x, y, width, height, scaleX, scaleY, text, multiline, color, fontSize, fontFace, maxLength, align, lineSpacing) {
         if (containerEle == null) {
             InitInput(inputEle = document.createElement("input"));
             InitInput(textareaEle = document.createElement("textarea"));
@@ -23,6 +23,12 @@ var WebGLTextInput = {
             canvasEle.parentElement.appendChild(containerEle);
         }
 
+        containerEle.style.top = y / devicePixelRatio + "px";
+        containerEle.style.left = x / devicePixelRatio + "px";
+        containerEle.style.width = width / devicePixelRatio + "px";
+        containerEle.style.height = height / devicePixelRatio + "px";
+        containerEle.style.transform = "scale(" + scaleX + "," + scaleY + ")";
+
         inputEle.parentElement && (containerEle.removeChild(inputEle));
         textareaEle.parentElement && (containerEle.removeChild(textareaEle));
 
@@ -32,18 +38,13 @@ var WebGLTextInput = {
 
         current.maxLength = maxLength <= 0 ? 1E5 : maxLength;
         current.value = UTF8ToString(text);
-        current.style.color = color;
-        current.style.fontSize = fontSize + 'px';
-        current.style.fontFamily = fontFace;
-        current.focus();
-    },
+        current.style.color = '#' + UTF8ToString(color);
+        current.style.fontSize = fontSize / devicePixelRatio + 'px';
+        current.style.fontFamily = UTF8ToString(fontFace);
+        current.style.textAlign = ['left','center','right'][align];
+        current.style.lineHeight = `calc(1.25em + ${lineSpacing / devicePixelRatio}px)`;
 
-    WebGLTextInputShow: function (x, y, width, height, scaleX, scaleY) {
-        containerEle.style.top = y + "px";
-        containerEle.style.left = x + "px";
-        containerEle.style.width = width + "px";
-        containerEle.style.height = height + "px";
-        containerEle.style.transform = "scale(" + scaleX + "," + scaleY + ")";
+        current.focus();
     },
 
     WebGLTextInputHide: function () {


### PR DESCRIPTION
修复：
1. Stage 下宏引用错误导致移动端无法正常触发屏幕键盘
2. 正确计算 HiDPI 下的位置和大小
3. 正确计算当有多个输入框时呼出屏幕键盘导致画面上推的幅度
4. 颜色
5. 字体名称

添加支持：
1. 对齐方式
2. 行距

解释一下关于合并了 WebGLTextInputSetText 和 WebGLTextInputShow 两个方法：
因为要先正确设置对容器的位置、后进行focus（focus的时候系统叫出屏幕键盘会用当时的位置来计算画面上推幅度）。
现在的结构下Set的时候不知道位置，Show的时候不知道current，如果把这两个调用顺序交换又会Show的时候没container，再考虑到这两个函数是 1:1 调用的于是请求将这两个函数掉合并。