### PR TITLE
fix sub/sup html tag line feed error

### DIFF
--- a/Assets/Scripts/Core/Text/TextField.cs
+++ b/Assets/Scripts/Core/Text/TextField.cs
@@ -840,7 +840,7 @@ namespace FairyGUI
                     {
                         if (sLineChars.Count > 0)
                         {
-                            wordLen = 2; //避免上标和下标折到下一行
+                            wordLen = 1; //避免上标和下标折到下一行
                             wordPossible = true;
                         }
                     }


### PR DESCRIPTION
上标和下标在计算可能是一个新行的时候的wordLen计算错误， 如果前边是几个英文字符，会让最后的一个字符在下一行显示，然后才显示sub/sup所包围的字符

<img width="703" height="198" alt="image" src="https://github.com/user-attachments/assets/b97edbf8-5e61-43c2-88df-e14d4860a0cf" />
