### PR TITLE
fix: restore stencil compare value for nested masks

### DIFF
--- a/Assets/Scripts/Core/UpdateContext.cs
+++ b/Assets/Scripts/Core/UpdateContext.cs
@@ -19,6 +19,7 @@ namespace FairyGUI
             public uint clipId;
             public int rectMaskDepth;
             public int referenceValue;
+            public int compareValue;
             public bool reversed;
         }
 
@@ -60,10 +61,12 @@ namespace FairyGUI
             batchingDepth = 0;
             rectMaskDepth = 0;
             stencilReferenceValue = 0;
+            stencilCompareValue = 0;
             alpha = 1;
             grayed = false;
 
             clipped = false;
+            clipInfo = default;
             _clipStack.Clear();
 
             Stats.ObjectCount = 0;
@@ -181,6 +184,7 @@ namespace FairyGUI
 
             clipInfo.clipId = clipId;
             clipInfo.referenceValue = stencilReferenceValue;
+            clipInfo.compareValue = stencilCompareValue;
             clipInfo.reversed = reversedMask;
             clipped = true;
         }
@@ -192,6 +196,7 @@ namespace FairyGUI
         {
             clipInfo = _clipStack.Pop();
             stencilReferenceValue = clipInfo.referenceValue;
+            stencilCompareValue = clipInfo.compareValue;
             rectMaskDepth = clipInfo.rectMaskDepth;
             clipped = stencilReferenceValue != 0 || rectMaskDepth != 0;
         }
@@ -203,7 +208,11 @@ namespace FairyGUI
 
             clipInfo.rectMaskDepth = 0;
             clipInfo.referenceValue = 0;
+            clipInfo.compareValue = 0;
             clipInfo.reversed = false;
+            rectMaskDepth = 0;
+            stencilReferenceValue = 0;
+            stencilCompareValue = 0;
             clipped = false;
         }
 
@@ -211,6 +220,7 @@ namespace FairyGUI
         {
             clipInfo = _clipStack.Pop();
             stencilReferenceValue = clipInfo.referenceValue;
+            stencilCompareValue = clipInfo.compareValue;
             rectMaskDepth = clipInfo.rectMaskDepth;
             clipped = stencilReferenceValue != 0 || rectMaskDepth != 0;
         }


### PR DESCRIPTION
### Problem
When using nested alpha masks, wrapped renderers such as Spine objects in `GLoader3D` can inherit a stale stencil compare value after an inner mask exits.
Example hierarchy:
```text
component1
  mask1
  spine11
  component12
    mask2
    spine21
    component22
      mask3
      spine31
      component32
        mask4
        spine41
      spine33
    spine23
  spine13
spine41 should be clipped by mask1 + mask2 + mask3 + mask4.

After leaving mask4, spine33 should only be clipped by mask1 + mask2 + mask3. However, UpdateContext.LeaveClipping() restores stencilReferenceValue but does not restore stencilCompareValue, so later sibling objects may still use the compare value from the inner mask.

This can make active and visible Spine objects fail stencil test and disappear.

### Cause
EnterClipping(uint clipId, bool reversedMask) updates both:

stencilReferenceValue
stencilCompareValue
But ClipInfo only stores referenceValue, so LeaveClipping() cannot restore the previous compare value.

GoWrapper objects apply the current clipping state directly to renderer materials through ApplyClippingProperties(), which makes this stale state visible on wrapped renderers such as Spine.

### Fix
Store stencilCompareValue in ClipInfo.
Restore it in LeaveClipping() and LeavePaintingMode().
Reset active stencil state in EnterPaintingMode() so it matches the existing Reset clipping behavior.

### Test
Tested in a Unity project with nested FairyGUI masks and Spine objects. After the fix, sibling Spine objects outside an inner mask no longer inherit the inner mask stencil compare value.